### PR TITLE
Workaround for the 64 characters problem

### DIFF
--- a/src/bosh-softlayer-cpi/action/create_vm.go
+++ b/src/bosh-softlayer-cpi/action/create_vm.go
@@ -32,9 +32,12 @@ func NewCreateVM(
 	return
 }
 
-func (a CreateVMAction) Run(agentID string, stemcellCID StemcellCID, cloudProps VMCloudProperties, networks Networks, diskIDs []DiskCID, env Environment) (string, error) {
-	a.updateCloudProperties(&cloudProps)
+func (a *CreateVMAction) GetVMCloudProperties() *VMCloudProperties {
+	return a.vmCloudProperties
+}
 
+func (a *CreateVMAction) Run(agentID string, stemcellCID StemcellCID, cloudProps VMCloudProperties, networks Networks, diskIDs []DiskCID, env Environment) (string, error) {
+	a.updateCloudProperties(&cloudProps)
 	helper.TIMEOUT = 30 * time.Second
 	helper.POLLING_INTERVAL = 5 * time.Second
 	helper.NetworkInterface = "eth0"
@@ -69,12 +72,11 @@ func (a CreateVMAction) Run(agentID string, stemcellCID StemcellCID, cloudProps 
 		if err != nil {
 			return "0", bosherr.WrapErrorf(err, "Creating Virtual_Guest with agent ID '%s'", agentID)
 		}
-
 		return VMCID(vm.ID()).String(), nil
 	}
 }
 
-func (a CreateVMAction) updateCloudProperties(cloudProps *VMCloudProperties) {
+func (a *CreateVMAction) updateCloudProperties(cloudProps *VMCloudProperties) {
 	a.vmCloudProperties = cloudProps
 
 	if len(cloudProps.BoshIp) == 0 || cloudProps.Baremetal {
@@ -94,11 +96,10 @@ func (a CreateVMAction) updateCloudProperties(cloudProps *VMCloudProperties) {
 	if len(cloudProps.Domain) == 0 {
 		a.vmCloudProperties.Domain = "softlayer.com"
 	}
-	helper.LengthOfHostName = len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
 	// A workaround for the issue #129 in bosh-softlayer-cpi
-	if helper.LengthOfHostName == 64 {
+	lengthOfHostName := len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
+	if lengthOfHostName == 64 {
 		a.vmCloudProperties.VmNamePrefix = a.vmCloudProperties.VmNamePrefix + "-1"
-		helper.LengthOfHostName = len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
 	}
 	if len(cloudProps.NetworkComponents) == 0 {
 		a.vmCloudProperties.NetworkComponents = []sldatatypes.NetworkComponents{{MaxSpeed: 1000}}

--- a/src/bosh-softlayer-cpi/action/create_vm.go
+++ b/src/bosh-softlayer-cpi/action/create_vm.go
@@ -95,7 +95,11 @@ func (a CreateVMAction) updateCloudProperties(cloudProps *VMCloudProperties) {
 		a.vmCloudProperties.Domain = "softlayer.com"
 	}
 	helper.LengthOfHostName = len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
-
+	// A workaround for the issue #129 in bosh-softlayer-cpi
+	if helper.LengthOfHostName == 64 {
+		a.vmCloudProperties.VmNamePrefix = a.vmCloudProperties.VmNamePrefix + "-1"
+		helper.LengthOfHostName = len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
+	}
 	if len(cloudProps.NetworkComponents) == 0 {
 		a.vmCloudProperties.NetworkComponents = []sldatatypes.NetworkComponents{{MaxSpeed: 1000}}
 	}

--- a/src/bosh-softlayer-cpi/action/create_vm_test.go
+++ b/src/bosh-softlayer-cpi/action/create_vm_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "bosh-softlayer-cpi/softlayer/common"
 	fakescommon "bosh-softlayer-cpi/softlayer/common/fakes"
+	helper "bosh-softlayer-cpi/softlayer/common/helper"
 	fakestem "bosh-softlayer-cpi/softlayer/stemcell/fakes"
 
 	sldatatypes "github.com/maximilien/softlayer-go/data_types"
@@ -66,7 +67,7 @@ var _ = Describe("CreateVM", func() {
 					StartCpus:    2,
 					MaxMemory:    2048,
 					Datacenter:   sldatatypes.Datacenter{Name: "fake-datacenter"},
-					VmNamePrefix: "fake-hostname",
+					VmNamePrefix: "fake-hostname123456789123456789",
 					BoshIp:       "10.0.0.0",
 					SshKeys: []sldatatypes.SshKey{
 						sldatatypes.SshKey{Id: 1234},
@@ -78,6 +79,8 @@ var _ = Describe("CreateVM", func() {
 				fakeStemcellFinder.FindByIdReturns(fakeStemcell, nil)
 				fakeCreatorProvider.GetReturns(fakeVmCreator)
 				fakeVmCreator.CreateReturns(fakeVm, nil)
+				Expect(helper.LengthOfHostName).ToNot(Equal(64))
+
 			})
 
 			It("fetches stemcell by id", func() {

--- a/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	slh "bosh-softlayer-cpi/softlayer/common/helper"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
@@ -82,11 +81,5 @@ func (s *fsAgentEnvService) Update(agentEnv AgentEnv) error {
 		time.Sleep(time.Duration(SL_CPI_WAIT_TIME_UPDATE_AGENT_ENV) * time.Second)
 	}
 
-	// Add this warning message due to bosh-softlayer-cpi issues #129, may remove this piece of code when we identify the real root cause
-	var longHostNameWarningMsg string
-	if slh.LengthOfHostName > 63 {
-		longHostNameWarningMsg = "Notice that the length of device hostname is greater than 63 characters, which might cause SSH service setup improperly by SoftLayer, please confirm with SoftLayer or consider to shorten the hostname"
-	}
-
-	return bosherr.WrapError(err, "Updating Agent Env timeout. "+longHostNameWarningMsg)
+	return bosherr.WrapError(err, "Updating Agent Env timeout. ")
 }

--- a/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service_test.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	fakebslvm "bosh-softlayer-cpi/softlayer/common/fakes"
-	slhelper "bosh-softlayer-cpi/softlayer/common/helper"
+
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 
 	. "github.com/onsi/ginkgo"
@@ -105,19 +105,6 @@ var _ = Describe("SoftlayerAgentEnvService", func() {
 			It("returns error with specific error message", func() {
 				err := agentEnvService.Update(newAgentEnv)
 				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("when the length of hostname is greater than 63 chars", func() {
-			BeforeEach(func() {
-				slhelper.LengthOfHostName = 64
-				fakeSoftlayerFileService.UploadErr = errors.New("A faked error occurred")
-			})
-
-			It("returns error with specific error message", func() {
-				err := agentEnvService.Update(newAgentEnv)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("the length of device hostname is greater than 63 characters"))
 			})
 		})
 	})

--- a/src/bosh-softlayer-cpi/softlayer/common/helper/softlayer_helper.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/helper/softlayer_helper.go
@@ -17,7 +17,6 @@ var (
 	TIMEOUT                   time.Duration
 	POLLING_INTERVAL          time.Duration
 	LocalDiskFlagNotSet       bool
-	LengthOfHostName          int
 	NetworkInterface          string
 	LocalDNSConfigurationFile string
 )

--- a/src/bosh-softlayer-cpi/softlayer/common/vm_utils.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/vm_utils.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"strconv"
 	"text/template"
 	"time"
 
@@ -35,7 +34,7 @@ func CreateDisksSpec(ephemeralDiskSize int) DisksSpec {
 
 func TimeStampForTime(now time.Time) string {
 	//utilize the constants list in the http://golang.org/src/time/format.go file to get the expect time formats
-	return now.Format("20060102-030405-") + strconv.Itoa(int(now.UnixNano()/1e6-now.Unix()*1e3))
+	return now.Format("20060102-030405-") + fmt.Sprintf("%03d", int(now.UnixNano()/1e6-now.Unix()*1e3))
 }
 
 func CreateVirtualGuestTemplate(stemcell bslcstem.Stemcell, cloudProps VMCloudProperties, networks Networks) (sldatatypes.SoftLayer_Virtual_Guest_Template, error) {

--- a/src/bosh-softlayer-cpi/softlayer/common/vm_utils_test.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/vm_utils_test.go
@@ -2,8 +2,8 @@ package common_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
-	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -97,7 +97,7 @@ var _ = Describe("VM Utils", func() {
 			timeStamp := TimeStampForTime(now)
 			Expect(timeStamp).ToNot(Equal(""))
 			prefix := now.Format("20060102-030405-")
-			suffix := strconv.Itoa(int(now.UnixNano()/1e6 - now.Unix()*1e3))
+			suffix := fmt.Sprintf("%03d", int(now.UnixNano()/1e6-now.Unix()*1e3))
 			Expect(timeStamp).To(Equal(prefix + suffix))
 		})
 	})


### PR DESCRIPTION
Hello,

(Copied from PR #196)

this PR addresses the issue #129. When the VM name is equal to 64 characters, the deployment is failing due to ssh problem (agent could not copy files to the VSI).

When the name with 64 characters was identified, a padding "-1" is appended to it.
I have removed the previous workaround for > 63 characters, since longer names are accepted.

@mattcui @maximilien Could you please have a look at this PR?