### PR TITLE
Workaround for 64 character vm name still with helper

### DIFF
--- a/src/bosh-softlayer-cpi/action/create_vm.go
+++ b/src/bosh-softlayer-cpi/action/create_vm.go
@@ -95,7 +95,11 @@ func (a CreateVMAction) updateCloudProperties(cloudProps *VMCloudProperties) {
 		a.vmCloudProperties.Domain = "softlayer.com"
 	}
 	helper.LengthOfHostName = len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
-
+	// A workaround for the issue #129 in bosh-softlayer-cpi
+	if helper.LengthOfHostName == 64 {
+		a.vmCloudProperties.VmNamePrefix = a.vmCloudProperties.VmNamePrefix + "-1"
+		helper.LengthOfHostName = len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
+	}
 	if len(cloudProps.NetworkComponents) == 0 {
 		a.vmCloudProperties.NetworkComponents = []sldatatypes.NetworkComponents{{MaxSpeed: 1000}}
 	}

--- a/src/bosh-softlayer-cpi/action/create_vm_test.go
+++ b/src/bosh-softlayer-cpi/action/create_vm_test.go
@@ -105,7 +105,7 @@ var _ = Describe("CreateVM", func() {
 			})
 		})
 
-		Context("when vm name with 64 characters was generated", func() {
+		Context("when vm name prefix is specified", func() {
 			BeforeEach(func() {
 				fakeOptions = &ConcreteFactoryOptions{
 					Softlayer: SoftLayerConfig{FeatureOptions: FeatureOptions{EnablePool: true}},
@@ -114,7 +114,7 @@ var _ = Describe("CreateVM", func() {
 					StartCpus:    2,
 					MaxMemory:    2048,
 					Datacenter:   sldatatypes.Datacenter{Name: "fake-datacenter"},
-					VmNamePrefix: "64chacter_long_name_with_suffix",
+					VmNamePrefix: "",
 					BoshIp:       "10.0.0.0",
 					SshKeys: []sldatatypes.SshKey{
 						sldatatypes.SshKey{Id: 1234},
@@ -126,15 +126,33 @@ var _ = Describe("CreateVM", func() {
 				fakeStemcellFinder.FindByIdReturns(fakeStemcell, nil)
 				fakeCreatorProvider.GetReturns(fakeVmCreator)
 				fakeVmCreator.CreateReturns(fakeVm, nil)
-				Expect(helper.LengthOfHostName).ToNot(Equal(64))
-
 			})
-
-			It("adds 2 additional characters to the name", func() {
-				Expect(helper.LengthOfHostName).To(Equal(66))
-				Expect(fakeStemcellFinder.FindByIdCallCount()).To(Equal(1))
-				actualId := fakeStemcellFinder.FindByIdArgsForCall(0)
-				Expect(actualId).To(Equal(1234))
+			Context("when vm name is < 64 character long", func() {
+				BeforeEach(func() {
+					fakeCloudProp.VmNamePrefix = "63charac_long_name_with_suffix"
+				})
+				It("does not modify the name length", func() {
+					Expect(helper.LengthOfHostName).To(Equal(63))
+					Expect(fakeStemcellFinder.FindByIdCallCount()).To(Equal(1))
+				})
+			})
+			Context("when vm name is exactly 64 character long", func() {
+				BeforeEach(func() {
+					fakeCloudProp.VmNamePrefix = "64charact_long_name_with_suffix"
+				})
+				It("adds 2 additional characters to the name", func() {
+					Expect(helper.LengthOfHostName).To(Equal(66))
+					Expect(fakeStemcellFinder.FindByIdCallCount()).To(Equal(1))
+				})
+			})
+			Context("when vm name > 64 characters", func() {
+				BeforeEach(func() {
+					fakeCloudProp.VmNamePrefix = "65characte_long_name_with_suffix"
+				})
+				It("does not modify the name length", func() {
+					Expect(helper.LengthOfHostName).To(Equal(65))
+					Expect(fakeStemcellFinder.FindByIdCallCount()).To(Equal(1))
+				})
 			})
 		})
 

--- a/src/bosh-softlayer-cpi/action/create_vm_test.go
+++ b/src/bosh-softlayer-cpi/action/create_vm_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "bosh-softlayer-cpi/softlayer/common"
 	fakescommon "bosh-softlayer-cpi/softlayer/common/fakes"
+	helper "bosh-softlayer-cpi/softlayer/common/helper"
 	fakestem "bosh-softlayer-cpi/softlayer/stemcell/fakes"
 
 	sldatatypes "github.com/maximilien/softlayer-go/data_types"
@@ -78,6 +79,7 @@ var _ = Describe("CreateVM", func() {
 				fakeStemcellFinder.FindByIdReturns(fakeStemcell, nil)
 				fakeCreatorProvider.GetReturns(fakeVmCreator)
 				fakeVmCreator.CreateReturns(fakeVm, nil)
+
 			})
 
 			It("fetches stemcell by id", func() {
@@ -100,6 +102,39 @@ var _ = Describe("CreateVM", func() {
 				Expect(actualEnv).To(Equal(env))
 				Expect(vmCidString).To(Equal(VMCID(fakeVm.ID()).String()))
 				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when vm name with 64 characters was generated", func() {
+			BeforeEach(func() {
+				fakeOptions = &ConcreteFactoryOptions{
+					Softlayer: SoftLayerConfig{FeatureOptions: FeatureOptions{EnablePool: true}},
+				}
+				fakeCloudProp = VMCloudProperties{
+					StartCpus:    2,
+					MaxMemory:    2048,
+					Datacenter:   sldatatypes.Datacenter{Name: "fake-datacenter"},
+					VmNamePrefix: "64chacter_long_name_with_suffix",
+					BoshIp:       "10.0.0.0",
+					SshKeys: []sldatatypes.SshKey{
+						sldatatypes.SshKey{Id: 1234},
+					},
+				}
+				action = NewCreateVM(fakeStemcellFinder, fakeCreatorProvider, *fakeOptions)
+
+				fakeVm.IDReturns(1234567)
+				fakeStemcellFinder.FindByIdReturns(fakeStemcell, nil)
+				fakeCreatorProvider.GetReturns(fakeVmCreator)
+				fakeVmCreator.CreateReturns(fakeVm, nil)
+				Expect(helper.LengthOfHostName).ToNot(Equal(64))
+
+			})
+
+			It("adds 2 additional characters to the name", func() {
+				Expect(helper.LengthOfHostName).To(Equal(66))
+				Expect(fakeStemcellFinder.FindByIdCallCount()).To(Equal(1))
+				actualId := fakeStemcellFinder.FindByIdArgsForCall(0)
+				Expect(actualId).To(Equal(1234))
 			})
 		})
 

--- a/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	slh "bosh-softlayer-cpi/softlayer/common/helper"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
@@ -82,11 +81,5 @@ func (s *fsAgentEnvService) Update(agentEnv AgentEnv) error {
 		time.Sleep(time.Duration(SL_CPI_WAIT_TIME_UPDATE_AGENT_ENV) * time.Second)
 	}
 
-	// Add this warning message due to bosh-softlayer-cpi issues #129, may remove this piece of code when we identify the real root cause
-	var longHostNameWarningMsg string
-	if slh.LengthOfHostName > 63 {
-		longHostNameWarningMsg = "Notice that the length of device hostname is greater than 63 characters, which might cause SSH service setup improperly by SoftLayer, please confirm with SoftLayer or consider to shorten the hostname"
-	}
-
-	return bosherr.WrapError(err, "Updating Agent Env timeout. "+longHostNameWarningMsg)
+	return bosherr.WrapError(err, "Updating Agent Env timeout. ")
 }

--- a/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service_test.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/fs_agent_env_service_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	fakebslvm "bosh-softlayer-cpi/softlayer/common/fakes"
-	slhelper "bosh-softlayer-cpi/softlayer/common/helper"
+
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 
 	. "github.com/onsi/ginkgo"
@@ -105,19 +105,6 @@ var _ = Describe("SoftlayerAgentEnvService", func() {
 			It("returns error with specific error message", func() {
 				err := agentEnvService.Update(newAgentEnv)
 				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("when the length of hostname is greater than 63 chars", func() {
-			BeforeEach(func() {
-				slhelper.LengthOfHostName = 64
-				fakeSoftlayerFileService.UploadErr = errors.New("A faked error occurred")
-			})
-
-			It("returns error with specific error message", func() {
-				err := agentEnvService.Update(newAgentEnv)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("the length of device hostname is greater than 63 characters"))
 			})
 		})
 	})

--- a/src/bosh-softlayer-cpi/softlayer/common/vm_utils.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/vm_utils.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"strconv"
 	"time"
 
 	sldatatypes "github.com/maximilien/softlayer-go/data_types"
@@ -16,6 +15,7 @@ import (
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 
 	"bufio"
+
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	sl "github.com/maximilien/softlayer-go/softlayer"
 )
@@ -34,7 +34,7 @@ func CreateDisksSpec(ephemeralDiskSize int) DisksSpec {
 
 func TimeStampForTime(now time.Time) string {
 	//utilize the constants list in the http://golang.org/src/time/format.go file to get the expect time formats
-	return now.Format("20060102-030405-") + strconv.Itoa(int(now.UnixNano()/1e6-now.Unix()*1e3))
+	return now.Format("20060102-030405-") + fmt.Sprintf("%03d", int(now.UnixNano()/1e6-now.Unix()*1e3))
 }
 
 func CreateVirtualGuestTemplate(stemcell bslcstem.Stemcell, cloudProps VMCloudProperties, networks Networks) (sldatatypes.SoftLayer_Virtual_Guest_Template, error) {

--- a/src/bosh-softlayer-cpi/softlayer/common/vm_utils_test.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/vm_utils_test.go
@@ -2,8 +2,8 @@ package common_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
-	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -99,7 +99,7 @@ var _ = Describe("VM Utils", func() {
 			timeStamp := TimeStampForTime(now)
 			Expect(timeStamp).ToNot(Equal(""))
 			prefix := now.Format("20060102-030405-")
-			suffix := strconv.Itoa(int(now.UnixNano()/1e6 - now.Unix()*1e3))
+			suffix := fmt.Sprintf("%03d", int(now.UnixNano()/1e6-now.Unix()*1e3))
 			Expect(timeStamp).To(Equal(prefix + suffix))
 		})
 	})


### PR DESCRIPTION
Hello, 

I resubmit the PR #205 that was eventually reverted. 
A couple of notes related to the previous discussion:

This PR is still using the [helper class](https://github.com/vvraskin/bosh-softlayer-cpi/blob/master/src/bosh-softlayer-cpi/action/create_vm.go#L9) in the create_vm action. I still needed some method to get the VM name length in the UT. The other option would be to create a public method to retrieve [vmCloudProperties](https://github.com/vvraskin/bosh-softlayer-cpi/blob/master/src/bosh-softlayer-cpi/action/create_vm.go#L31), however that requires Run method in the create_vm.go to reference the same object. In other words I need to change methods to the reference type, which causes failures on [json_caller.go](https://github.com/cloudfoundry/bosh-softlayer-cpi-release/blob/27b8cdb2d92381ccf741058d88151a88bf79a991/src/bosh-softlayer-cpi/api/dispatcher/json_caller.go#L27). That makes me believe, that using the helper method is still a valid option.

Let me know what you think @mattcui @maximilien 

regards, Vadim 

