### PR TITLE
Add ci tasks of cpi unit-test, integration-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,21 @@
 # BOSH Softlayer CPI Release
 
+| Concourse Job      | Sub Job | Status                                                                                                                                                                                                                               |
+| ---                | ---     | ---                                                                                                                                                                                                                             |
+| BATS               | TBD | |
+| integration        | run-lifecycle | [![bosh-sl-ci.bluemix.net](https://bosh-sl-ci.bluemix.net/api/v1/pipelines/wip:lite:bosh:softlayer:cpi:release/jobs/run-lifecycle/badge)](https://bosh-sl-ci.bluemix.net/pipelines/wip:lite:bosh:softlayer:cpi:release/jobs/run-lifecycle) |
+| unit tests         | build-candidate | [![bosh-sl-ci.bluemix.net](https://bosh-sl-ci.bluemix.net/api/v1/pipelines/wip:lite:bosh:softlayer:cpi:release/jobs/build-candidate/badge)](https://bosh-sl-ci.bluemix.net/pipelines/wip:lite:bosh:softlayer:cpi:release/jobs/build-candidate) |
+
 * Documentation: [bosh.io/docs](https://bosh.io/docs)
 * BOSH SoftLayer CPI Slack channel: #bosh-softlayer-cpi on [https://cloudfoundry.slack.com/](https://cloudfoundry.slack.com/)
 * Mailing list: [cf-bosh](https://lists.cloudfoundry.org/pipermail/cf-bosh)
-* CI: <https://bosh-sl-ci.bluemix.net/teams/main/pipelines/bosh-softlayer-cpi-release-v4>
+* CI: <https://bosh-sl-ci.bluemix.net/teams/main/pipelines/wip:lite:bosh:softlayer:cpi:release>
 * Roadmap: [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1344876)
-
-## Releases
 
 This is a BOSH release for the Softlayer CPI.
 
-The latest version for the SoftlLayer CPI release is here. Also, it is already available on [bosh.io](http://bosh.io).
+See [Initializing a BOSH environment on Softlayer](https://bosh.io/docs/init-softlayer.html) for example usage.
 
-To use this CPI you will need to use the SoftLayer light stemcell. it's also available on [bosh.io](http://bosh.io).
+## Development
 
-## Bootstrap on SoftLayer
-
-You can use bosh-init from community to bootstrap an environment.
-
-See [bosh-init-usage](docs/bosh-init-usage.md). Use the CPI and stemcells releases above to do so.
-
-## Deployment Manifests Samples
-
-For Cloud Config, see [sl-cloud-config](docs/sl-cloud-config.yml)
-
-For Concourse, follow the guide of [Cluster with BOSH](http://concourse.ci/clusters-with-bosh.html) and reference the deployment manifest sample in ```Deploying Concourse``` section.
-
-For a minimalistic deployment of Cloud Foundry (diego architecture), follow the introduction  [minimalistic_cf_deployment.md](docs/minimalistic_cf_deployment.md).
-
-## Frequently Asked Questions and Answers
-
-1. Q: How do I specify a dynamic network through subnet instead of vlan id?
-
-   A: We don't support it currently.
-
-2. Q: Is there any restrictions about the hostname supported by Softlayer?
-
-   A: Yes. The hostname length can't be exactly 64. Otherwise there will be problems with ssh login.
+See [development doc](docs/README.md).

--- a/ci/pipeline_lite.yml
+++ b/ci/pipeline_lite.yml
@@ -16,10 +16,23 @@ jobs:
     - put: bosh-cpi-dev-artifacts
       params: {file: candidate/*.tgz}
 
+  - name: run-lifecycle
+    serial: true
+    plan:
+    - aggregate:
+      - {trigger: true,  passed: [build-candidate], get: bosh-cpi-dev-artifacts}
+      - {trigger: false, passed: [build-candidate], get: bosh-cpi-release, resource: bosh-cpi-release-in}
+
+    - task: test
+      file: bosh-cpi-src/ci/tasks/run-lifecycle.yml
+      params:
+        SL_USERNAME: {{sl_username}}
+        SL_API_KEY:  {{sl_api_key}}
+
   - name: promote-candidate
     plan:
     - aggregate:
-      - {trigger: true,  get: bosh-cpi-dev-artifacts, passed: [build-candidate]}
+      - {trigger: true,  get: bosh-cpi-dev-artifacts, passed: [run-lifecycle]}
       - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-release-in}
       - {trigger: false, get: version-semver,  resource: version-semver}
 

--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -10,25 +10,23 @@ chmod +x ${BOSH_CLI}
 pushd bosh-cpi-release
 
   source .envrc
+  pushd src/bosh-softlayer-cpi > /dev/null
+    echo "[build-candidate] Installing ginkgo"
+    go get github.com/onsi/ginkgo/ginkgo
+    echo "[build-candidate] Set GO15VENDOREXPERIMENT=1 for using go1.5"
+    export GO15VENDOREXPERIMENT=1
+
+    echo "[build-candidate] Running unit tests"
+    ./bin/test-unit
+  popd > /dev/null
 
   echo $semver > src/bosh-softlayer-cpi/version
 
   cpi_release_name="bosh-softlayer-cpi"
   tarball_name="dev_releases/${cpi_release_name}/${cpi_release_name}-${semver}.tgz"
-  echo "building CPI release..."
+  echo "[build-candidate] Building CPI release..."
 
   $BOSH_CLI create-release --name $cpi_release_name --version $semver --tarball $tarball_name --force
 popd
 
 mv bosh-cpi-release/$tarball_name candidate/
-
-
-
-
-
-
-
-
-
-
-

--- a/ci/tasks/run-lifecycle.sh
+++ b/ci/tasks/run-lifecycle.sh
@@ -4,55 +4,18 @@ set -e
 
 source bosh-cpi-release/ci/tasks/utils.sh
 
-check_param AZURE_CLIENT_ID
-check_param AZURE_CLIENT_SECRET
-check_param AZURE_TENANT_ID
-check_param AZURE_GROUP_NAME
-check_param AZURE_STORAGE_ACCOUNT_NAME
-check_param AZURE_SUBSCRIPTION_ID
-check_param SSH_CERTIFICATE
-check_param AZURE_VNET_NAME_FOR_LIFECYCLE
-check_param AZURE_BOSH_SUBNET_NAME
+check_param SL_USERNAME
+check_param SL_API_KEY
 
-export BOSH_AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}
-export BOSH_AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME}
-export BOSH_AZURE_RESOURCE_GROUP_NAME=${AZURE_GROUP_NAME}
-export BOSH_AZURE_TENANT_ID=${AZURE_TENANT_ID}
-export BOSH_AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
-export BOSH_AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
-export BOSH_AZURE_VNET_NAME=${AZURE_VNET_NAME_FOR_LIFECYCLE}
-export BOSH_AZURE_SUBNET_NAME=${AZURE_BOSH_SUBNET_NAME}
+export SL_USERNAME=${SL_USERNAME}
+export SL_API_KEY=${SL_API_KEY}
 
-source /etc/profile.d/chruby.sh
-chruby 2.2.4
+pushd bosh-cpi-release/src/bosh-softlayer-cpi > /dev/null
+  echo "[run-lifecycle] Installing ginkgo"
+  go get github.com/onsi/ginkgo/ginkgo
+  echo "[run-lifecycle] Set GO15VENDOREXPERIMENT=1 for using go1.5"
+  export GO15VENDOREXPERIMENT=1
 
-azure login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
-azure config mode arm
-
-AZURE_STORAGE_ACCESS_KEY=$(azure storage account keys list ${AZURE_STORAGE_ACCOUNT_NAME} -g ${AZURE_GROUP_NAME} --json | jq '.storageAccountKeys.key1' -r)
-
-export BOSH_AZURE_STEMCELL_ID="bosh-stemcell-00000000-0000-0000-0000-0AZURECPICI0"
-export AZURE_STORAGE_ACCOUNT=${AZURE_STORAGE_ACCOUNT_NAME}
-export AZURE_STORAGE_ACCESS_KEY
-
-# Upload stemcell if it does not exist.
-# Lifycycle is used to test CPI but not stemcell so you can use any valid stemcell.
-set +e
-azure storage blob show stemcell ${BOSH_AZURE_STEMCELL_ID}.vhd
-if [ $? -eq 1 ]; then
-  tar -xf ${PWD}/stemcell/*.tgz -C /mnt/
-  tar -xf /mnt/image -C /mnt/
-  azure storage blob upload -q --blobtype PAGE /mnt/root.vhd stemcell ${BOSH_AZURE_STEMCELL_ID}.vhd
-fi
-set -e
-
-echo write cert to file
-echo "$SSH_CERTIFICATE" > /tmp/azurecert
-echo cert written to file
-tail -n1 /tmp/azurecert
-export BOSH_AZURE_CERTIFICATE_FILE="/tmp/azurecert"
-
-cd bosh-cpi-release/src/bosh_azure_cpi
-
-bundle install
-bundle exec rspec spec/integration
+  echo "[run-lifecycle] Running integration tests"
+  ./bin/test-integration
+popd > /dev/null

--- a/ci/tasks/run-lifecycle.yml
+++ b/ci/tasks/run-lifecycle.yml
@@ -1,18 +1,17 @@
 ---
 platform: linux
-image: docker:///boshcpi/azure-cpi-release
+
+image_resource:
+  type: docker-image
+  source:
+    repository: cloudfoundry/bosh-lite-ci
+
 inputs:
 - name: bosh-cpi-release
-- name: stemcell
+
 run:
   path: bosh-cpi-release/ci/tasks/run-lifecycle.sh
+
 params:
-  AZURE_CLIENT_ID:                replace-me
-  AZURE_CLIENT_SECRET:            replace-me
-  AZURE_TENANT_ID:                replace-me
-  AZURE_GROUP_NAME:               replace-me
-  AZURE_STORAGE_ACCOUNT_NAME:     replace-me
-  AZURE_SUBSCRIPTION_ID:          replace-me
-  SSH_CERTIFICATE:                replace-me
-  AZURE_VNET_NAME_FOR_LIFECYCLE:  replace-me
-  AZURE_BOSH_SUBNET_NAME:         replace-me
+  SL_USERNAME:           replace-me
+  SL_API_KEY:            replace-me

--- a/src/bosh-softlayer-cpi/bin/test-integration
+++ b/src/bosh-softlayer-cpi/bin/test-integration
@@ -39,5 +39,5 @@ else
 fi
 
   echo -e "\n Vetting packages for potential issues..."
-  go tool vet action api common integration main test_helpers
+  go tool vet action api integration main test_helpers
 )

--- a/src/bosh-softlayer-cpi/bin/test_integration
+++ b/src/bosh-softlayer-cpi/bin/test_integration
@@ -39,5 +39,5 @@ else
 fi
 
   echo -e "\n Vetting packages for potential issues..."
-  go tool vet action api common integration main test_helpers
+  go tool vet action api integration main test_helpers
 )


### PR DESCRIPTION
Add unit-test, integration-test of softlayer cpi to concourse tasks.

1. The build-candidate task runs the unit-test and creates the release.
2. The run-lifesyscle task runs the integration-test.

@jianqiu Please take a review. Thanks.
