### PR TITLE
Revert "Add 'Preconfigured' for config agent networks"

### DIFF
--- a/src/bosh-softlayer-cpi/action/create_vm_test.go
+++ b/src/bosh-softlayer-cpi/action/create_vm_test.go
@@ -145,13 +145,12 @@ var _ = Describe("CreateVM", func() {
 				Mbus: "nats://nats:nats@fake-mbus:fake-port",
 				Networks: registry.NetworksSettings{
 					"fake-network-name": registry.NetworkSettings{
-						Type:          "dynamic",
-						IP:            "10.10.10.10",
-						Gateway:       "fake-network-gateway",
-						Netmask:       "fake-network-netmask",
-						DNS:           []string{"fake-network-dns"},
-						Default:       []string{"fake-network-default"},
-						Preconfigured: true,
+						Type:    "dynamic",
+						IP:      "10.10.10.10",
+						Gateway: "fake-network-gateway",
+						Netmask: "fake-network-netmask",
+						DNS:     []string{"fake-network-dns"},
+						Default: []string{"fake-network-default"},
 					},
 				},
 				Env: registry.EnvSettings(map[string]interface{}{
@@ -325,13 +324,12 @@ var _ = Describe("CreateVM", func() {
 				Mbus: fmt.Sprintf("nats://nats:nats@%s:fake-port", localIpAddr),
 				Networks: registry.NetworksSettings{
 					"fake-network-name": registry.NetworkSettings{
-						Type:          "dynamic",
-						IP:            "10.10.10.10",
-						Gateway:       "fake-network-gateway",
-						Netmask:       "fake-network-netmask",
-						DNS:           []string{"fake-network-dns"},
-						Default:       []string{"fake-network-default"},
-						Preconfigured: true,
+						Type:    "dynamic",
+						IP:      "10.10.10.10",
+						Gateway: "fake-network-gateway",
+						Netmask: "fake-network-netmask",
+						DNS:     []string{"fake-network-dns"},
+						Default: []string{"fake-network-default"},
 					},
 				},
 				Env: registry.EnvSettings(map[string]interface{}{
@@ -408,13 +406,12 @@ var _ = Describe("CreateVM", func() {
 				Mbus: "nats://nats:nats@10.11.12.13:fake-port",
 				Networks: registry.NetworksSettings{
 					"fake-network-name": registry.NetworkSettings{
-						Type:          "dynamic",
-						IP:            "10.10.10.10",
-						Gateway:       "fake-network-gateway",
-						Netmask:       "fake-network-netmask",
-						DNS:           []string{"fake-network-dns"},
-						Default:       []string{"fake-network-default"},
-						Preconfigured: true,
+						Type:    "dynamic",
+						IP:      "10.10.10.10",
+						Gateway: "fake-network-gateway",
+						Netmask: "fake-network-netmask",
+						DNS:     []string{"fake-network-dns"},
+						Default: []string{"fake-network-default"},
 					},
 				},
 				Env: registry.EnvSettings(map[string]interface{}{
@@ -469,106 +466,6 @@ var _ = Describe("CreateVM", func() {
 				Datacenter:        "fake-datacenter",
 				SshKey:            32345678,
 				DeployedByBoshCLI: true,
-			}
-
-			vmCID, err = createVM.Run(agentID, stemcellCID, cloudProps, networks, disks, env)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(imageService.FindCallCount()).To(Equal(1))
-			Expect(vmService.CreateSshKeyCallCount()).To(Equal(0))
-			Expect(vmService.GetVlanCallCount()).To(Equal(1))
-			Expect(vmService.FindByPrimaryBackendIpCallCount()).To(Equal(1))
-			Expect(vmService.ReloadOSCallCount()).To(Equal(1))
-			Expect(vmService.CreateCallCount()).To(Equal(0))
-			Expect(vmService.ConfigureNetworksCallCount()).To(Equal(1))
-			Expect(vmService.AttachEphemeralDiskCallCount()).To(Equal(0))
-			Expect(vmService.CleanUpCallCount()).To(Equal(0))
-			Expect(registryClient.UpdateCalled).To(BeTrue())
-			Expect(vmService.FindCallCount()).To(Equal(1))
-			Expect(registryClient.UpdateSettings).To(Equal(expectedAgentSettings))
-			actualCid, _ := vmService.ConfigureNetworksArgsForCall(0)
-			Expect(vmCID).To(Equal(VMCID(actualCid).String()))
-			_, actualInstanceNetworks := vmService.ConfigureNetworksArgsForCall(0)
-			Expect(actualInstanceNetworks).To(Equal(expectedInstanceNetworks))
-		})
-
-		It("creates the vm successfully when dns is empty", func() {
-			cloudProps = VMCloudProperties{
-				HostnamePrefix:    "fake-randomstring-346e9mlcy90i4n57oc0zk-hostname",
-				Domain:            "fake-domain.com",
-				Cpu:               2,
-				Memory:            2048,
-				MaxNetworkSpeed:   100,
-				Datacenter:        "fake-datacenter",
-				SshKey:            32345678,
-				DeployedByBoshCLI: true,
-			}
-
-			networks = Networks{
-				"fake-network-name": Network{
-					Type:    "dynamic",
-					IP:      "10.10.10.10",
-					Gateway: "fake-network-gateway",
-					Netmask: "fake-network-netmask",
-					Default: []string{"fake-network-default"},
-					CloudProperties: NetworkCloudProperties{
-						VlanIds:             []int{42345678},
-						SourcePolicyRouting: true,
-					},
-				},
-			}
-
-			vmService.ConfigureNetworksReturns(
-				instance.Networks{
-					"fake-network-name": instance.Network{
-						Type:    "dynamic",
-						IP:      "10.10.10.10",
-						Gateway: "fake-network-gateway",
-						Netmask: "fake-network-netmask",
-						DNS:     []string{},
-						Default: []string{"fake-network-default"},
-						CloudProperties: instance.NetworkCloudProperties{
-							VlanID:              42345678,
-							SourcePolicyRouting: true,
-						},
-					},
-				},
-				nil,
-			)
-
-			expectedInstanceNetworks = networks.AsInstanceServiceNetworks(&datatypes.Network_Vlan{})
-
-			expectedAgentSettings = registry.AgentSettings{
-				AgentID: "fake-agent-id",
-				Blobstore: registry.BlobstoreSettings{
-					Provider: "dav",
-					Options:  map[string]interface{}{"endpoint": "http://fake-blobstore:fake-port"},
-				},
-				Disks: registry.DisksSettings{
-					System:     "",
-					Persistent: map[string]registry.PersistentSettings{},
-				},
-				Mbus: "nats://nats:nats@fake-mbus:fake-port",
-				Networks: registry.NetworksSettings{
-					"fake-network-name": registry.NetworkSettings{
-						Type:          "dynamic",
-						IP:            "10.10.10.10",
-						Gateway:       "fake-network-gateway",
-						Netmask:       "fake-network-netmask",
-						DNS:           []string{},
-						Default:       []string{"fake-network-default"},
-						Preconfigured: false,
-					},
-				},
-				Env: registry.EnvSettings(map[string]interface{}{
-					"bosh": map[string]interface{}{
-						"keep_root_password": true,
-						"groups":             []interface{}{"fake-tag"},
-					},
-				}),
-
-				VM: registry.VMSettings{
-					Name: "52345678",
-				},
 			}
 
 			vmCID, err = createVM.Run(agentID, stemcellCID, cloudProps, networks, disks, env)
@@ -834,13 +731,12 @@ var _ = Describe("CreateVM", func() {
 					Mbus: "nats://nats:nats@fake-mbus:fake-port",
 					Networks: registry.NetworksSettings{
 						"fake-network-name": registry.NetworkSettings{
-							Type:          "dynamic",
-							IP:            "10.10.10.10",
-							Gateway:       "fake-network-gateway",
-							Netmask:       "fake-network-netmask",
-							DNS:           []string{"fake-network-dns"},
-							Default:       []string{"fake-network-default"},
-							Preconfigured: true,
+							Type:    "dynamic",
+							IP:      "10.10.10.10",
+							Gateway: "fake-network-gateway",
+							Netmask: "fake-network-netmask",
+							DNS:     []string{"fake-network-dns"},
+							Default: []string{"fake-network-default"},
 						},
 					},
 					Env: registry.EnvSettings(map[string]interface{}{
@@ -1019,13 +915,12 @@ var _ = Describe("CreateVM", func() {
 					Mbus: "nats://nats:nats@fake-mbus:fake-port",
 					Networks: registry.NetworksSettings{
 						"fake-network-name": registry.NetworkSettings{
-							Type:          "dynamic",
-							IP:            "10.10.10.10",
-							Gateway:       "fake-network-gateway",
-							Netmask:       "fake-network-netmask",
-							DNS:           []string{"fake-network-dns"},
-							Default:       []string{"fake-network-default"},
-							Preconfigured: true,
+							Type:    "dynamic",
+							IP:      "10.10.10.10",
+							Gateway: "fake-network-gateway",
+							Netmask: "fake-network-netmask",
+							DNS:     []string{"fake-network-dns"},
+							Default: []string{"fake-network-default"},
 						},
 					},
 					Env: registry.EnvSettings(map[string]interface{}{"bosh": map[string]interface{}{"keep_root_password": true, "groups": []interface{}{"fake-tag"}}}),
@@ -1185,13 +1080,12 @@ var _ = Describe("CreateVM", func() {
 					Mbus: "nats://nats:nats@fake-mbus:fake-port",
 					Networks: registry.NetworksSettings{
 						"fake-network-name": registry.NetworkSettings{
-							Type:          "dynamic",
-							IP:            "10.10.10.10",
-							Gateway:       "fake-network-gateway",
-							Netmask:       "fake-network-netmask",
-							DNS:           []string{"fake-network-dns"},
-							Default:       []string{"fake-network-default"},
-							Preconfigured: true,
+							Type:    "dynamic",
+							IP:      "10.10.10.10",
+							Gateway: "fake-network-gateway",
+							Netmask: "fake-network-netmask",
+							DNS:     []string{"fake-network-dns"},
+							Default: []string{"fake-network-default"},
 						},
 					},
 					Env: registry.EnvSettings(map[string]interface{}{
@@ -1267,13 +1161,12 @@ var _ = Describe("CreateVM", func() {
 					Mbus: "nats://nats:nats@fake-mbus:fake-port",
 					Networks: registry.NetworksSettings{
 						"fake-network-name": registry.NetworkSettings{
-							Type:          "dynamic",
-							IP:            "10.10.10.10",
-							Gateway:       "fake-network-gateway",
-							Netmask:       "fake-network-netmask",
-							DNS:           []string{"fake-network-dns"},
-							Default:       []string{"fake-network-default"},
-							Preconfigured: true,
+							Type:    "dynamic",
+							IP:      "10.10.10.10",
+							Gateway: "fake-network-gateway",
+							Netmask: "fake-network-netmask",
+							DNS:     []string{"fake-network-dns"},
+							Default: []string{"fake-network-default"},
 						},
 					},
 					Env: registry.EnvSettings(map[string]interface{}{

--- a/src/bosh-softlayer-cpi/registry/agent_settings.go
+++ b/src/bosh-softlayer-cpi/registry/agent_settings.go
@@ -109,9 +109,6 @@ type NetworkSettings struct {
 
 	Routes Routes `json:"routes,omitempty"`
 
-	// Does network is preconfigured
-	Preconfigured bool `json:"preconfigured"`
-
 	// Network cloud properties
 	CloudProperties map[string]interface{} `json:"cloud_properties"`
 }

--- a/src/bosh-softlayer-cpi/softlayer/virtual_guest_service/networks.go
+++ b/src/bosh-softlayer-cpi/softlayer/virtual_guest_service/networks.go
@@ -76,16 +76,15 @@ func (n Networks) AsRegistryNetworks() registry.NetworksSettings {
 
 	for netName, network := range n {
 		networksSettings[netName] = registry.NetworkSettings{
-			Type:          network.Type,
-			IP:            network.IP,
-			Mac:           network.MAC,
-			Gateway:       network.Gateway,
-			Netmask:       network.Netmask,
-			DNS:           network.DNS,
-			Default:       network.Default,
-			Alias:         network.Alias,
-			Routes:        network.Routes,
-			Preconfigured: len(network.DNS) != 0,
+			Type:    network.Type,
+			IP:      network.IP,
+			Mac:     network.MAC,
+			Gateway: network.Gateway,
+			Netmask: network.Netmask,
+			DNS:     network.DNS,
+			Default: network.Default,
+			Alias:   network.Alias,
+			Routes:  network.Routes,
 		}
 	}
 

--- a/src/bosh-softlayer-cpi/softlayer/virtual_guest_service/networks_test.go
+++ b/src/bosh-softlayer-cpi/softlayer/virtual_guest_service/networks_test.go
@@ -231,22 +231,20 @@ var _ = Describe("Networks", func() {
 
 			expectNetworksSettings := registry.NetworksSettings{
 				"fake-network-name1": registry.NetworkSettings{
-					Type:          "dynamic",
-					IP:            "10.10.10.10",
-					Gateway:       "fake-network-gateway",
-					Netmask:       "fake-network-netmask",
-					DNS:           []string{"fake-network-dns1"},
-					Default:       []string{"fake-network-default"},
-					Preconfigured: true,
+					Type:    "dynamic",
+					IP:      "10.10.10.10",
+					Gateway: "fake-network-gateway",
+					Netmask: "fake-network-netmask",
+					DNS:     []string{"fake-network-dns1"},
+					Default: []string{"fake-network-default"},
 				},
 				"fake-network-name2": registry.NetworkSettings{
-					Type:          "manual",
-					IP:            "12.10.10.10",
-					Gateway:       "fake-network-gateway",
-					Netmask:       "fake-network-netmask",
-					DNS:           []string{"fake-network-dns2"},
-					Default:       []string{"fake-network-default"},
-					Preconfigured: true,
+					Type:    "manual",
+					IP:      "12.10.10.10",
+					Gateway: "fake-network-gateway",
+					Netmask: "fake-network-netmask",
+					DNS:     []string{"fake-network-dns2"},
+					Default: []string{"fake-network-default"},
 				},
 			}
 


### PR DESCRIPTION
Hi,

SL CPI hands over networks configuration to bosh-agent. About compatibility, old CPI would set preconfigure as `True` and bosh-agent would write `resolv.conf` and `interfaces` files both. And this commit would set preconfigure as `False` and bosh-agent would only write `interfaces` file including IP and DNS records.

Passed BATs.
