### PR TITLE
Remove bosh.env.password override

### DIFF
--- a/src/bosh-softlayer-cpi/action/create_vm.go
+++ b/src/bosh-softlayer-cpi/action/create_vm.go
@@ -104,11 +104,6 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 
 	if boshenv, ok := env["bosh"]; ok {
 		boshenv.(map[string]interface{})["keep_root_password"] = true
-
-		// #148050011: Set vcap password in env.bosh.password through CPI
-		if env["bosh"].(map[string]interface{})["password"] == nil && cv.agentOptions.VcapPassword != "" {
-			env["bosh"].(map[string]interface{})["password"] = cv.agentOptions.VcapPassword
-		}
 	}
 
 	// CID for returned VM

--- a/src/bosh-softlayer-cpi/action/create_vm_test.go
+++ b/src/bosh-softlayer-cpi/action/create_vm_test.go
@@ -1170,7 +1170,6 @@ var _ = Describe("CreateVM", func() {
 						"bosh": map[string]interface{}{
 							"keep_root_password": true,
 							"groups":             []interface{}{"fake-tag"},
-							"password":           "fake-vcap-password-in-agent",
 						},
 					}),
 


### PR DESCRIPTION
This override violates the contract between BOSH and the CPI. It also contradicts BOSH documentation. By removing this override, the vcap user is locked by default, but can be unlocked by specifying bosh.env.password